### PR TITLE
ABC registration files for Internal API Developer Portal

### DIFF
--- a/ABC.yaml
+++ b/ABC.yaml
@@ -2,13 +2,13 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: ABC
-  description: Descriptionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
+  description: Descriptionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn2
   labels:
     access: private
   tags:
     - recommended
 spec:
-  type: business domain
+  type: platform domain
   lifecycle: design
   owner: cy-tester
   definition:


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.