### PR TITLE
ABC registration files for Internal API Developer Portal

### DIFF
--- a/ABC.yaml
+++ b/ABC.yaml
@@ -1,4 +1,4 @@
-apiVersion: backstage.io/v1alpha1
+gapiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: ABC
@@ -9,7 +9,7 @@ metadata:
     - recommended
 spec:
   type: business domain
-  lifecycle: development
+  lifecycle: design
   owner: cy-tester
   definition:
     $text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/abc/latest.json

--- a/ABC.yaml
+++ b/ABC.yaml
@@ -4,12 +4,12 @@ metadata:
   name: ABC
   description: Descriptionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
   labels:
-    access: private
+    access: internal
   tags:
     - recommended
 spec:
-  type: business domain
-  lifecycle: design
+  type: platform domain
+  lifecycle: development
   owner: cy-tester
   definition:
     $text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/abc/latest.json

--- a/ABC.yaml
+++ b/ABC.yaml
@@ -8,7 +8,7 @@ metadata:
   tags:
     - recommended
 spec:
-  type: platform domain
+  type: business domain
   lifecycle: development
   owner: cy-tester
   definition:


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.