### PR TITLE
ABC registration files for Internal API Developer Portal

### DIFF
--- a/ABC.yaml
+++ b/ABC.yaml
@@ -1,15 +1,15 @@
-gapiVersion: backstage.io/v1alpha1
+apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: ABC
-  description: Descriptionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn2
+  description: Descriptionnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn
   labels:
-    access: internal
+    access: private
   tags:
     - recommended
 spec:
-  type: platform domain
-  lifecycle: design
+  type: business domain
+  lifecycle: development
   owner: cy-tester
   definition:
     $text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/abc/latest.json


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.